### PR TITLE
Add GH action to  fmt & validate Terraform configuration

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,78 @@
+name: "TF GH Action"
+on:
+  - pull_request
+
+env:
+  TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
+
+jobs:
+  fmt:
+    name: "fmt"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1.2.0
+        with:
+          terraform_version: 0.12.26
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -recursive -write=false -check -diff .
+        continue-on-error: true
+
+      - name: Post Github Comment
+        uses: actions/github-script@v3.0.0
+        if: github.event_name == 'pull_request' && steps.fmt.outputs.exitcode != 0
+        env:
+          TF_FMT_STDOUT: "${{ steps.fmt.outputs.stdout }}"
+          GIT_COMMIT_GH_USER: "${{ github.event.sender.login }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style Failed 🔥
+
+            Hi @${process.env.GIT_COMMIT_GH_USER}, you have Terraform code that is improperly formatted.
+
+            To fix this, please run:
+            \`\`\`bash
+            terraform fmt -recursive .
+            \`\`\`
+
+            <details><summary>Show fmt output</summary>
+
+            \`\`\`diff
+            ${process.env.TF_FMT_STDOUT}
+            \`\`\`
+
+            </details>`;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+            core.setFailed(" Please run: terraform fmt -recursive");
+
+  validate:
+    name: "validate"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform_version: [0.12.26, 0.13.2]
+    steps:
+      - name: Checkout
+        uses: Iterable/checkout@v2.3.1
+
+      - name: Setup Terraform ${{ matrix.terraform_version }}
+        uses: Iterable/setup-terraform@v1.1.0
+        with:
+          terraform_version: ${{ matrix.terraform_version }}
+
+      - name: Terraform Validate
+        id: validate
+        run: for example in examples/*/; do cd "${GITHUB_WORKSPACE}/${example}" && terraform init -backend=false && terraform validate -no-color ; done

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1.2.0
         with:
-          terraform_version: 0.12.26
+          terraform_version: 0.13.2
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,10 +66,10 @@ jobs:
         terraform_version: [0.12.26, 0.13.2]
     steps:
       - name: Checkout
-        uses: Iterable/checkout@v2.3.1
+        uses: actions/checkout@v2.3.2
 
       - name: Setup Terraform ${{ matrix.terraform_version }}
-        uses: Iterable/setup-terraform@v1.1.0
+        uses: hashicorp/setup-terraform@v1.2.0
         with:
           terraform_version: ${{ matrix.terraform_version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .terraform
+
+# IDE
+.idea

--- a/examples/aws_vault_resources/main.tf
+++ b/examples/aws_vault_resources/main.tf
@@ -1,10 +1,11 @@
 provider "aws" {
+  region = "us-east-1"
 }
 
 module "aws_vault" {
   source = "../../provision/aws_vault_resources"
   prefix = "myorg-prod"
   resource_tags = {
-    Enviroment: "Production"
+    Enviroment : "Production"
   }
 }

--- a/provision/aws_role/main.tf
+++ b/provision/aws_role/main.tf
@@ -5,7 +5,13 @@
  * an existing role and attaches the specified policy.
  * This is primarily to be used by other modules
  */
-provider "aws" {
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 2.70.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }
 
 variable "role_tags" {

--- a/provision/aws_tiered_storage/main.tf
+++ b/provision/aws_tiered_storage/main.tf
@@ -22,7 +22,13 @@
  * }
  * ```
  */
-provider "aws" {
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 2.70.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }
 
 variable "bucket_name" {

--- a/provision/aws_vault_resources/main.tf
+++ b/provision/aws_vault_resources/main.tf
@@ -22,7 +22,13 @@
  * }
  * ```
  */
-provider "aws" {
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 2.70.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }
 
 variable "prefix" {


### PR DESCRIPTION
## Changes
* Add Github action to run `fmt` using version 0.13.2
  - Fix the Terraform module configuration in `examples/aws_vault_storage` by adding a space character to get the `fmt` command to succeed.
* Add Github action to run `validate` using the latest 0.12.x and 0.13.x versions
  - Fix invalid Terraform configuration in `examples/aws_vault_storage` by adding AWS region parameter in the provider to get the `validate` command to succeed.
  - Fix invalid Terraform module configurations in `provision/*/main.tf` removing explicit `provider` declaration and instead add a `provider requirement` block to get the `validate` command to succeed (See: [provider-requirements](https://www.terraform.io/docs/configuration/provider-requirements.html#v0-12-compatible-provider-requirements))
* Rename `example/` directory to `examples/`
